### PR TITLE
Do not overwrite on merging to avoid permission errors

### DIFF
--- a/denops/dpp/deps.ts
+++ b/denops/dpp/deps.ts
@@ -14,6 +14,7 @@ export * as autocmd from "https://deno.land/x/denops_std@v5.0.2/autocmd/mod.ts";
 export { ensure, is } from "https://deno.land/x/unknownutil@v3.10.0/mod.ts";
 export {
   assertEquals,
+  assertInstanceOf,
   equal,
 } from "https://deno.land/std@0.206.0/assert/mod.ts";
 export {

--- a/denops/dpp/utils.ts
+++ b/denops/dpp/utils.ts
@@ -1,4 +1,11 @@
-import { assertEquals, copy, Denops, is, join } from "./deps.ts";
+import {
+  assertEquals,
+  assertInstanceOf,
+  copy,
+  Denops,
+  is,
+  join,
+} from "./deps.ts";
 import { Plugin } from "./types.ts";
 
 export async function errorException(
@@ -74,8 +81,12 @@ export async function safeStat(path: string): Promise<Deno.FileInfo | null> {
 export async function linkPath(hasWindows: boolean, src: string, dest: string) {
   if (!hasWindows) {
     // NOTE: For non Windows, copy() is faster...
-    await copy(src, dest, { overwrite: true });
-    return;
+    try {
+      await copy(src, dest, { overwrite: false });
+      return;
+    } catch (e) {
+      assertInstanceOf(e, Deno.errors.AlreadyExists);
+    }
   }
 
   if (await isDirectory(src)) {


### PR DESCRIPTION
In Linux (and probably MacOS as well) systems, merging causes permission errors on overwriting a file (like .gitignore) when a source directory is read-only, because `copy` in deno_std preserve the permissions of the original file for the copied one.

This PR proposes a possible solution, which simply disables overwriting and asserts the type of errors.

Feel free to ask me more information, or close the PR if it doesn't fit your favor.