### PR TITLE
fix: merge incomplete in non windows

### DIFF
--- a/denops/dpp/deps.ts
+++ b/denops/dpp/deps.ts
@@ -32,4 +32,3 @@ export {
 } from "https://deno.land/std@0.209.0/async/mod.ts";
 export { TimeoutError } from "https://deno.land/x/msgpack_rpc@v4.0.1/response_waiter.ts";
 export { Lock } from "https://deno.land/x/async@v2.0.2/mod.ts";
-export { copy } from "https://deno.land/std@0.209.0/fs/mod.ts";

--- a/denops/dpp/utils.ts
+++ b/denops/dpp/utils.ts
@@ -1,7 +1,6 @@
 import {
   assertEquals,
   assertInstanceOf,
-  copy,
   Denops,
   is,
   join,
@@ -79,20 +78,6 @@ export async function safeStat(path: string): Promise<Deno.FileInfo | null> {
 }
 
 export async function linkPath(hasWindows: boolean, src: string, dest: string) {
-  if (!hasWindows) {
-    try {
-      // NOTE: For non Windows, copy() is faster...
-      await copy(src, dest, { overwrite: false });
-    } catch (e) {
-      // NOTE: In Linux (and probably MacOS as well) systems, merging causes
-      // permission errors on overwriting a file (like .gitignore) when a
-      // source directory is read-only, because copy in deno_std preserve the
-      // permissions of the original file for the copied one.
-      assertInstanceOf(e, Deno.errors.AlreadyExists);
-    }
-    return;
-  }
-
   if (await isDirectory(src)) {
     if (!await safeStat(dest)) {
       // Not exists directory


### PR DESCRIPTION
`copy()` stop at found non-overwritable file first. And this function when works correctly is similar to following routine. So remove it for fix merge problem.