### PR TITLE
fix(lua): treat `load_state` as a boolean function

### DIFF
--- a/lua/dpp.lua
+++ b/lua/dpp.lua
@@ -11,7 +11,7 @@ local M = setmetatable({}, {
       local ret = vim.call('dpp#' .. key, ...)
 
       -- NOTE: For boolean functions
-      if type(ret) ~= 'table' and (vim.startswith(key, 'check_') or vim.startswith(key, 'is_')) then
+      if type(ret) ~= 'table' and (vim.startswith(key, 'check_') or vim.startswith(key, 'is_')) or key == 'min#load_state' then
         ret = ret ~= 0
       end
 


### PR DESCRIPTION
This fixes a problem with the Lua example in README.md that `make_state` is called even when `load_state` succeeds.