### PR TITLE
Fix overwrite tag file of plugin

### DIFF
--- a/denops/dpp/dpp.ts
+++ b/denops/dpp/dpp.ts
@@ -387,6 +387,10 @@ export class Dpp {
         }
 
         for await (const entry of Deno.readDir(srcDir)) {
+          if (entry.name.match(/^tags(?:-\w\w)?$/)) {
+            // Skip exists tag file to avoid overwrite
+            continue;
+          }
           await linkPath(
             hasWindows,
             join(srcDir, entry.name),


### PR DESCRIPTION
For example, `vim-jp/vimdoc-ja` contains tag file.
When using it, create link to tag file and overwritten at `:helptags`.
This change to avoid tag file.