### PR TITLE
Fix counting of nested marker

### DIFF
--- a/denops/dpp/utils.ts
+++ b/denops/dpp/utils.ts
@@ -123,6 +123,8 @@ export function parseHooksFile(
         continue;
       }
 
+      nestedCount++;
+
       hookName = match.groups.hookName;
       if (
         hookName.startsWith("hook_") ||
@@ -147,7 +149,7 @@ export function parseHooksFile(
         // End marker
         nestedCount--;
 
-        if (nestedCount < 0) {
+        if (nestedCount <= 0) {
           // Nested end
           hookName = "";
           continue;


### PR DESCRIPTION
Fixed a bug that “comment2” was treated as a ftplugin when parsing the code shown below, because the first marker was not counted up.

```vim
" hook_add {{{
" comment1 {{{
" }}}

" comment2 {{{
" }}}
" }}}
```