### PR TITLE
update: Add extra_args to check_files argument

### DIFF
--- a/autoload/dpp.vim
+++ b/autoload/dpp.vim
@@ -87,9 +87,10 @@ function dpp#clear_state(
 endfunction
 
 function dpp#check_files(
-      \   name=g:->get('dpp#_name', v:progname->fnamemodify(':r'))
+      \   name=g:->get('dpp#_name', v:progname->fnamemodify(':r')),
+      \   extra_args={}
       \ ) abort
-  return dpp#util#_check_files(a:name)
+  return dpp#util#_check_files(a:name, a:extra_args)
 endfunction
 
 function dpp#check_clean() abort

--- a/autoload/dpp/util.vim
+++ b/autoload/dpp/util.vim
@@ -25,12 +25,12 @@ endfunction
 function dpp#util#_get_runtime_path() abort
   return dpp#util#_substitute_path($VIMRUNTIME)
 endfunction
-function dpp#util#_check_files(name) abort
+function dpp#util#_check_files(name, extra_args={}) abort
   const time = printf('%s/%s/state.vim', g:dpp#_base_path, a:name)->getftime()
   const updated = g:dpp#_check_files->copy()
         \ ->filter({ _, val -> time < val->dpp#util#_expand()->getftime() })
   if !updated->empty() && 'g:dpp#_config_path'->exists()
-    call dpp#make_state(g:dpp#_base_path, g:dpp#_config_path, a:name)
+    call dpp#make_state(g:dpp#_base_path, g:dpp#_config_path, a:name, a:extra_args)
   endif
 
   return updated

--- a/doc/dpp.txt
+++ b/doc/dpp.txt
@@ -149,10 +149,12 @@ dpp#check_clean()
 		NOTE: It must be executed after |dpp#min#load_state()|.
 
                                                            *dpp#check_files()*
-dpp#check_files([{name}])
+dpp#check_files([{name}, {extra-args}])
 		Check dpp.vim cache file is outdated.
 		{name} is plugins profile name.  The default is "vim" or
 		"nvim".
+		{extra-args} is extra arguments dictionary.  It can be used in
+		{config-path} TypeScript.
 		If it is outdated, |dpp#make_state()| is called
 		automatically.
 		It should be called when |BufWritePost| autocmd.


### PR DESCRIPTION
## Overview

Due to the addition of `extra_args` to the `make_state` function, it became necessary to also pass `extra_args` to the `check_files` function to avoid the following issue.

As a prerequisite, the user checks the type of `extra_args` inside `make_state` using tools like `unknownutil`.
If `check_files` is executed without the changes introduced in this PR, the type check for `extra_args` is triggered within `make_state`, and since `extra_args` is not passed in the expected format, a type error occurs.
At this time, due to the definition of `make_state`, a default empty dictionary is passed as `extra_args`.
Therefore, the appropriate data expected by `make_state` also needs to be passed during the execution of `check_files`.

## Changes Made

- Added the `extra_args` parameter to `check_files` in the same manner as in `make_state`.
- Added an explanation of `extra_args` to the documentation of `check_files`, following the same format as in `make_state`.
