### PR TITLE
fix: stop to call `_call_hook` when sourced is empty

### DIFF
--- a/autoload/dpp/source.vim
+++ b/autoload/dpp/source.vim
@@ -28,7 +28,9 @@ function dpp#source#_source(plugins, function_prefix) abort
 
   let &runtimepath = rtps->dpp#util#_join_rtp(&runtimepath, '')
 
-  call dpp#util#_call_hook('source', sourced)
+  if !sourced->empty()
+    call dpp#util#_call_hook('source', sourced)
+  endif
 
   if a:function_prefix->stridx('#') > 0
     " NOTE: Reload autoload script
@@ -118,7 +120,7 @@ function dpp#source#_source(plugins, function_prefix) abort
     silent! let &l:filetype = &l:filetype
   endif
 
-  if !has('vim_starting')
+  if !has('vim_starting') && !sourced->empty()
     call dpp#util#_call_hook('post_source', sourced)
   endif
 


### PR DESCRIPTION
close #41

## Summary

Stop to call `_call_hook` when `sourced` is empty.

## Details

`dpp#util#_call_hook` treats `[]` as 'all sourced plugins' via `_get_plugins([])`.

When `dpp#source#_source` is invoked for a plugin that is sourced already,
the local 'sourced' list ends up empty,
and calling `_call_hook` with that empty list re-fires `hook_source` for
every plugin marked sourced including non-lazy plugins whose
`hook_source` was inlined into startup.vim and never went through `_execute_hook`
(so the called guard does not protect them).

So, skip the call when sourced is empty for both `source` and `post_source`.

## Confirmation

This fixes #41
